### PR TITLE
Mirror of SonarSource sonarqube#3211

### DIFF
--- a/server/sonar-db-dao/src/main/java/org/sonar/db/DaoUtils.java
+++ b/server/sonar-db-dao/src/main/java/org/sonar/db/DaoUtils.java
@@ -56,8 +56,6 @@ public class DaoUtils {
    */
   private static String escapePercentAndUnderscore(String value) {
     return value
-        .replaceAll("/", "//")
-        .replaceAll("%", "/%")
-        .replaceAll("_", "/_");
+        .replaceAll("/" + "|" + "%" + "|" + "_", "/$0"); // $0 : Group zero, stands for the entire expression
   }
 }


### PR DESCRIPTION
Mirror of SonarSource sonarqube#3211
Perfomance and factorising issue.
Use one regex instead of 3 by factorising the matched expression with captured group zero.

First PR, please be kind :-)

For the record: while working on https://community.sonarsource.com/t/new-rule-to-check-if-first-argument-of-string-replaceall-is-really-a-regexp/10085 I was searching if there is some possible use in Sonar.
Found this where each of 3 ".replaceAll" can be replaced by ".replace" (because first argument is not a regex) but then the 3 ".replace" can be replaced by one replaceAll with this time a true regex. :-)
